### PR TITLE
Add Help Command

### DIFF
--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,0 +1,32 @@
+use poise::builtins::HelpConfiguration;
+use crate::bot_types::{_Context as Context, Error};
+
+/// Display Help & Command menu.
+#[poise::command(prefix_command)]
+pub async fn help (
+    ctx: Context<'_>,
+    #[description = "Command to get help for."]
+    #[rest]
+    mut command: Option<String>
+) -> Result<(), Error> {
+    if ctx.invoked_command_name() != "help" {
+        command = match command {
+            Some(c) => Some(format!("{} {}", ctx.invoked_command_name(), c)),
+            None => Some(ctx.invoked_command_name().to_string()),
+        };
+    }
+
+    let extra_text_at_bottom = "\
+    Type `!help <command> for more info.";
+
+    let config = HelpConfiguration {
+        show_subcommands: true,
+        show_context_menu_commands: true,
+        ephemeral: true,
+        extra_text_at_bottom,
+
+        ..Default::default()
+    };
+    poise::builtins::help(ctx, command.as_deref(), config).await?;
+    Ok(())
+}

--- a/src/commands/judge.rs
+++ b/src/commands/judge.rs
@@ -5,6 +5,8 @@ use crate::bot_types::{ Error, _Context as Context};
 use poise::{ serenity_prelude as serenity};
 use serenity::model::channel::ReactionType;
 
+/// Use as a reply to have the bot judge a users post.
+/// *Noted for deprecation.
 #[poise::command(prefix_command)]
 pub async fn judge(ctx: Context<'_>) -> Result<(), Error> {
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod judge;
 pub mod score;
 pub mod trade;
 pub mod shop;
+pub mod help;

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,7 +1,7 @@
 use crate::bot_types::{Error, _Context as Context };
 use poise::serenity_prelude as serenity;
-use serenity::all::Timestamp;
 
+/// Just a test command. Does nothing.
 #[poise::command(prefix_command)]
 pub async fn ping(ctx: Context<'_>,
                   #[description = "Selected User"] user: Option<serenity::User>,

--- a/src/commands/shop.rs
+++ b/src/commands/shop.rs
@@ -120,6 +120,7 @@ pub async fn update_shop_count(item_name: String, current_increase: i16, total_i
 
 }
 
+/// Returns the current amount of an item.
 #[poise::command(prefix_command, aliases("count", "getCount"))]
 pub async fn item_count(
     ctx: Context<'_>,

--- a/src/commands/smash.rs
+++ b/src/commands/smash.rs
@@ -6,6 +6,7 @@ Returns smash or pass.
 use crate::bot_utils;
 use crate::bot_types::{Error, _Context as Context};
 
+/// Smash or Pass a message. Used as a reply.
 #[poise::command(prefix_command)]
 pub async fn smash(ctx: Context<'_>) -> Result<(), Error>{
     let mut reply = if bot_utils::get_random_bool(0.5) {"Smash"} else {"Pass"};

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use crate::commands::score::*;
 use crate::commands::ping::*;
 use crate::commands::trade::*;
 use crate::commands::shop::*;
+use crate::commands::help::*;
 
 use crate::bot_types::{Data, Error};
 
@@ -170,7 +171,7 @@ async fn main() {
 
     let framework = poise::Framework::<Data, Error>::builder()
         .options(poise::FrameworkOptions {
-            commands: vec![ping(), judge(), score(), top(), leader(), smash(), trade(), wallet(), shop(), item_count()],
+            commands: vec![ping(), judge(), score(), top(), leader(), smash(), trade(), wallet(), shop(), item_count(), help()],
             prefix_options: poise::PrefixFrameworkOptions {
                 prefix: Some("!".into()),
                 ..Default::default()


### PR DESCRIPTION
Adds a help command !help <command> that gives information regarding the command. 
If no <command> is supplied then will return a list of available commands. 